### PR TITLE
Improve error handling & tweak backoff values

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -41,7 +41,7 @@ var wsSocketFn = require('../transports/ws');
 var retryPolicyFromOptions = require('../retry-policies').retryPolicyFromOptions;
 
 var rtmStartAttempts = [];
-var MAX_RTM_START_PER_HOUR = process.env.SLACK_MAX_RTM_START_PER_HOUR || 15;
+var MAX_RTM_START_PER_HOUR = process.env.SLACK_MAX_RTM_START_PER_HOUR || 50;
 
 function hasExceededRtmStartLimit() {
   const oneHourAgo = Date.now() - 60 * 60 * 1000;

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -41,7 +41,7 @@ var wsSocketFn = require('../transports/ws');
 var retryPolicyFromOptions = require('../retry-policies').retryPolicyFromOptions;
 
 var rtmStartAttempts = [];
-var MAX_RTM_START_PER_HOUR = process.env.SLACK_MAX_RTM_START_PER_HOUR || 60;
+var MAX_RTM_START_PER_HOUR = process.env.SLACK_MAX_RTM_START_PER_HOUR || 15;
 
 function hasExceededRtmStartLimit() {
   const oneHourAgo = Date.now() - 60 * 60 * 1000;
@@ -320,6 +320,11 @@ RTMClient.prototype._onStart = function _onStart(requestError, data) {
     this.disconnect(reason, error);
   }, this);
 
+  if (!(this._connecting || this._reconnecting)) {
+    this.logger('warn', '_onStart called after disconnect');
+    return;
+  }
+
   this._connecting = false;
   this._reconnecting = false;
 
@@ -396,6 +401,8 @@ RTMClient.prototype.connect = function connect(socketUrl) {
 RTMClient.prototype.disconnect = function disconnect(optErr, optCode) {
   this.emit(CLIENT_EVENTS.DISCONNECT, optErr, optCode);
   this.autoReconnect = false;
+  this._connecting = false;
+  this._reconnecting = false;
   this._safeDisconnect();
 };
 

--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -36,21 +36,23 @@ var handleTransportError = function handleTransportError(err, retryOp, apiCb) {
 var handleRateLimitResponse = function handleRateLimitResponse(retryArgs, headers) {
   var client = retryArgs.client;
   var retryAfter = parseInt(headers['retry-after'], 10);
-  var headerSecs = Number.isInteger(retryAfter) ? retryAfter : 60;
+  var headerSecs = Number.isInteger(retryAfter) ? retryAfter : 60 * 5;
   var headerMs = headerSecs * 1000;
-  client.logger('info', 'Rate limited, will retry %s seconds', headerSecs);
 
-  client.requestQueue.pause();
-
-  setTimeout(function retryRateLimitedRequest() {
-    // Don't retry limit requests that were rejected due to retry-after
-    client.transport(retryArgs.task.args, partial(handleTransportResponse, retryArgs));
-    client.requestQueue.resume();
-  }, headerMs);
+  // XXX It is important that rate limited requests don't bypass the
+  // retry system. In the original impl a continually rate limited
+  // request would keep trying forever. To fix this, have the retry
+  // logic use the larger of retry-after or the next timeout
+  var timeouts = retryArgs.retryOp._timeouts;
+  if (timeouts && timeouts.length > 0) {
+    timeouts[0] = Math.max(headerMs, timeouts[0]);
+    client.logger('info', 'Rate limited, will retry %s seconds', timeouts[0]);
+  }
+  var retval = handleHttpErr(retryArgs.retryOp, retryArgs.task.cb, 429);
 
   client.emit(WEB_CLIENT_EVENTS.RATE_LIMITED, headerSecs);
 
-  return false;
+  return retval;
 };
 
 


### PR DESCRIPTION
###  Summary

- Const tweaks: 
  - Be more aggressive about giving up when repeatedly getting disconnected. 60 felt too high as you could be reconnecting about once a minute and still not quite trigger the threshold. 15 may be too low. Thoughts?
  - Turn the default rate limited case up to 5 minutes. `electron-fetch` is munging our headers and forcing us into this case, then we get trapped forever since the real rate limit can be more than a minute
- Handle edge case where `disconnect` is called while the `rtm.connect` call is still in progress. Without this change a `disconnect`ed client would still start up and connect itself once the HTTP call finished
- Avoid case where rate limited requests would continue retrying forever, with no way to cancel or shut down
  - The old logic assumed you would eventually stop being rate limited and therefor did a separate `setTimeout`, bypassing the queue and retry system.
  - This PR adds an ugly hack that combines the rate limit value with the retry system, so that it will back off further than the rate limit, eventually give up, and allow for cancellation of queued tasks

### Testing

- Forced a `ws.close()` in `_handleHello`, to simulate being disconnected after fully connecting
- Set up a rtm client to use shorter retry config, connect repeatedly, and eventually hit the rate limit
- Confirmed that the retry works as expected

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
