### PR TITLE
Support setting the proxy URL

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -92,6 +92,7 @@ function RTMClient(token, opts) {
    * @type {Function}
    */
   this._socketFn = clientOpts.socketFn || wsSocketFn;
+  this._proxyURL = clientOpts.proxyURL;
 
   /**
    * The active websocket.
@@ -384,7 +385,7 @@ RTMClient.prototype._safeDisconnect = function _safeDisconnect() {
  */
 RTMClient.prototype.connect = function connect(socketUrl) {
   this.emit(CLIENT_EVENTS.WS_OPENING);
-  this.ws = this._socketFn(socketUrl);
+  this.ws = this._socketFn(socketUrl, { proxyURL: this._proxyURL });
 
   this.ws.on('open', bind(this.handleWsOpen, this));
   this.ws.on('message', bind(this.handleWsMessage, this));

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "^1.5.0",
     "bluebird": "^3.3.3",
     "eventemitter3": "^1.1.1",
-    "https-proxy-agent": "^1.0.0",
+    "https-proxy-agent": "^2.1.1",
     "inherits": "^2.0.1",
     "lodash": "^4.13.1",
     "pkginfo": "^0.4.0",


### PR DESCRIPTION
##  Summary
The default `socketFn` will use `https-proxy-agent` if given a [`proxyURL` parameter](https://github.com/slackapi/node-slack-sdk/blob/master/lib/clients/transports/ws.js#L23), but we need a way to pass parameters _to_ the socket function. This also upgrades the `https-proxy-agent` dependency to the latest version.
