### PR TITLE
Connect to Flannel instead

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -384,8 +384,13 @@ RTMClient.prototype._safeDisconnect = function _safeDisconnect() {
  * @param {String} socketUrl The URL of the websocket to connect to.
  */
 RTMClient.prototype.connect = function connect(socketUrl) {
+  const flannelUrl = (socketUrl.indexOf('?') > 0) ?
+    `${socketUrl}&flannel=3&token=${this._token}` :
+    `${socketUrl}?flannel=3&token=${this._token}`;
+  this.logger('debug', `Connecting to ${flannelUrl}`);
+
   this.emit(CLIENT_EVENTS.WS_OPENING);
-  this.ws = this._socketFn(socketUrl, { proxyURL: this._proxyURL });
+  this.ws = this._socketFn(flannelUrl, { proxyURL: this._proxyURL });
 
   this.ws.on('open', bind(this.handleWsOpen, this));
   this.ws.on('message', bind(this.handleWsMessage, this));


### PR DESCRIPTION
##  Summary
This PR modifies the websocket URL to connect to [Flannel](https://slack-github.com/slack/docs/blob/master/flannel_client.md). We need both a `&flannel` arg as well as the `token` for auth. Interestingly, it turns out there's no reason to go through the `rtm.connect` flow; we could build the Flannel socket URL ourselves.

🤔 Which really makes you think – why are we using `node-slack-sdk` at all?

But that's a question for another day.

## Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
